### PR TITLE
feat: Revert array to object change in plulist v2

### DIFF
--- a/customer-config/checkout-config/che.plulist.v2.json
+++ b/customer-config/checkout-config/che.plulist.v2.json
@@ -20,6 +20,13 @@
           "format": "date",
           "example": "2021-01-01"
         },
+        "id": {
+          "description": "A unique identifier for the PLU list.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 20,
+          "example": "top-5-items-plu"
+        },
         "name": {
           "description": "The PLU List name",
           "type": "string",

--- a/customer-config/checkout-config/che.plulist.v2.json
+++ b/customer-config/checkout-config/che.plulist.v2.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/extenda/hiiretail-json-schema-registry/master/customer-config/checkout-config/che.plulist.v2.json",
   "title": "PLU List message",
-  "type": "object",
-  "additionalProperties": {
+  "type": "array",
+  "items": {
     "$ref": "#/$defs/PluListType"
   },
   "$defs": {


### PR DESCRIPTION
Because of the lack of ordering and easier migration, the change from an array to an object for the top level structure is reverted in the v2 plulist schema