### PR TITLE
fix(HCC-9645): POS zoomFactor support

### DIFF
--- a/customer-config/checkout-app/cha.settings.v1.json
+++ b/customer-config/checkout-app/cha.settings.v1.json
@@ -89,6 +89,11 @@
         "kiosk"
       ],
       "properties": {
+        "zoomFactor": {
+          "description": "The zoom factor for the pos and sco application.",
+          "type": "number",
+          "#ref": "#/$defs/ZoomFactorType"
+        },
         "server": {
           "description": "Server settings.",
           "type": "object",
@@ -786,6 +791,11 @@
         "autoStart"
       ],
       "properties": {
+        "zoomFactor": {
+          "description": "The zoom factor for the cfd application.",
+          "type": "number",
+          "#ref": "#/$defs/ZoomFactorType"
+        },
         "autoStart": {
           "type": "boolean",
           "default": false,
@@ -796,6 +806,28 @@
           "description": "Welcome message to display on the customer facing display."
         }
       }
+    },
+    "ZoomFactorType": {
+      "type": "number",
+      "enum": [
+        0.6,
+        0.7,
+        0.8,
+        0.9,
+        1,
+        1.1,
+        1.2,
+        1.3,
+        1.4,
+        1.5,
+        1.6,
+        1.7,
+        1.8,
+        1.9,
+        2
+      ],
+      "default": 1,
+      "description": "The zoom factor for the application."
     }
   }
 }


### PR DESCRIPTION
Cause: [Checkout app](https://github.com/extenda/hiiretail-checkout-ui/pull/1564)

allows configuring the zoom factor for both the POS and CFD applications
