### PR TITLE
feat: Add attendant basket workstation and task event schemas

### DIFF
--- a/external-events/att/att.private.notification.basket-deleted.v1.json
+++ b/external-events/att/att.private.notification.basket-deleted.v1.json
@@ -1,0 +1,12 @@
+{
+  "$id": "att.private.notification.basket-deleted.v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Publishes Attendant Basket deleted events",
+  "description": "This schema describes the structure of the Attendant Basket deleted events published by the Attendant service when a basket is deleted.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  }
+}

--- a/external-events/att/att.private.notification.baskets.v1.json
+++ b/external-events/att/att.private.notification.baskets.v1.json
@@ -1,0 +1,93 @@
+{
+  "$id": "att.private.notification.baskets.v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Publishes Attendant Basket events",
+  "description": "This schema describes the structure of the Attendant Basket events published by the Attendant service when a basket is created or updated.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "workstationId": {
+      "type": "string"
+    },
+    "workstationChannel": {
+      "nullable": true,
+      "allOf": [
+        {
+          "$ref": "#/$defs/WorkstationChannel"
+        }
+      ]
+    },
+    "locale": {
+      "type": "string",
+      "description": "ICU locale",
+      "example": "en-US"
+    },
+    "status": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/BasketStatus"
+        }
+      ]
+    },
+    "currency": {
+      "type": "string",
+      "description": "ISO 4127 currency name",
+      "example": "EUR"
+    },
+    "itemCount": {
+      "type": "number",
+      "minimum": 0
+    },
+    "totalAmount": {
+      "type": "number"
+    },
+    "totalDiscount": {
+      "type": "number",
+      "description": "Can be positive or negative (or zero). The format depends on the producer of the receipt."
+    },
+    "voidedItems": {
+      "type": "number",
+      "minimum": 0
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "nullable": true
+    },
+    "receipt": {
+      "type": "object"
+    }
+  },
+  "$defs": {
+    "BasketStatus": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "CANCELLED",
+        "SUSPENDED",
+        "FINALIZED",
+        "RESUMED",
+        "PAYMENT",
+        "IMPORTED",
+        "ERROR"
+      ]
+    },
+    "WorkstationChannel": {
+      "type": "string",
+      "enum": [
+        "SCANNGO",
+        "MYSCAN",
+        "ERPOS",
+        "SUPERPOS",
+        "HIICHECKOUT",
+        "MCPE"
+      ]
+    }
+  }
+}

--- a/external-events/att/att.private.notification.task-deleted.v1.json
+++ b/external-events/att/att.private.notification.task-deleted.v1.json
@@ -1,0 +1,15 @@
+{
+  "$id": "att.private.notification.task-deleted.v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Publishes Attendant Task deleted events",
+  "description": "This schema describes the structure of the Attendant Task deleted events published by the Attendant service when a task is deleted.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/external-events/att/att.private.notification.task-processed.v1.json
+++ b/external-events/att/att.private.notification.task-processed.v1.json
@@ -1,0 +1,37 @@
+{
+  "$id": "att.private.notification.task-processed.v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Publishes Attendant Task processed events",
+  "description": "This schema describes the structure of the Attendant Task processed events published by the Attendant service when a task is processed.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "status": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/TaskStatus"
+        }
+      ]
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": [
+    "id",
+    "status",
+    "updatedAt"
+  ],
+  "$defs": {
+    "TaskStatus": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "processed"
+      ]
+    }
+  }
+}

--- a/external-events/att/att.private.notification.tasks.v1.json
+++ b/external-events/att/att.private.notification.tasks.v1.json
@@ -1,0 +1,143 @@
+{
+  "$id": "att.private.notification.tasks.v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Publishes Attendant Task events",
+  "description": "This schema describes the structure of the Attendant Task events published by the Attendant service when a task is created or updated.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "vendor": {
+      "type": "string"
+    },
+    "title": {
+      "$ref": "#/$defs/TextWithLocaleDto"
+    },
+    "description": {
+      "$ref": "#/$defs/TextWithLocaleDto"
+    },
+    "device": {
+      "nullable": true,
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/TaskDeviceDto"
+        }
+      ]
+    },
+    "controls": {
+      "nullable": true,
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/ConfirmControlDto"
+        }
+      ]
+    },
+    "status": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/TaskStatus"
+        }
+      ]
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "requestedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "processedAt": {
+      "type": "string",
+      "format": "date-time",
+      "nullable": true
+    }
+  },
+  "$defs": {
+    "ConfirmControlDto": {
+      "type": "object",
+      "properties": {
+        "actions": {
+          "minItems": 2,
+          "maxItems": 2,
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AssistanceRequestActionDto"
+          }
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "CONFIRM"
+          ]
+        }
+      },
+      "required": [
+        "actions",
+        "type"
+      ]
+    },
+    "AssistanceRequestActionDto": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "label": {
+          "$ref": "#/$defs/TextWithLocaleDto"
+        },
+        "isDefault": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "label"
+      ]
+    },
+    "TaskDeviceDto": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type"
+      ]
+    },
+    "TaskStatus": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "processed"
+      ]
+    },
+    "TextWithLocaleDto": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value",
+        "locale"
+      ]
+    }
+  }
+}

--- a/external-events/att/att.private.notification.workstation-deleted.v1.json
+++ b/external-events/att/att.private.notification.workstation-deleted.v1.json
@@ -1,0 +1,8 @@
+{
+  "$id": "att.private.notification.workstation-deleted.v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Publishes Attendant Workstation deleted events",
+  "description": "This schema describes the structure of the Attendant Workstation deleted events published by the Attendant service when a workstation is deleted.",
+  "type": "object",
+  "properties": {}
+}

--- a/external-events/att/att.private.notification.workstations.v1.json
+++ b/external-events/att/att.private.notification.workstations.v1.json
@@ -1,0 +1,156 @@
+{
+  "$id": "att.private.notification.workstations.v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Publishes Attendant Workstation events",
+  "description": "This schema describes the structure of the Attendant Workstation events published by the Attendant service when a workstation is created or updated.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "businessUnitId": {
+      "type": "string"
+    },
+    "state": {
+      "example": "IDLE",
+      "allOf": [
+        {
+          "$ref": "#/$defs/WorkstationState"
+        }
+      ]
+    },
+    "type": {
+      "example": "SCO",
+      "allOf": [
+        {
+          "$ref": "#/$defs/WorkstationType"
+        }
+      ]
+    },
+    "channel": {
+      "nullable": true,
+      "example": "SUPERPOS",
+      "allOf": [
+        {
+          "$ref": "#/$defs/WorkstationChannel"
+        }
+      ]
+    },
+    "currentBasket": {
+      "nullable": true,
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/CurrentBasket"
+        }
+      ]
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "monitored": {
+      "type": "boolean",
+      "default": false
+    },
+    "manualRescanInProgress": {
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "$defs": {
+    "CurrentBasket": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "voidedItems": {
+          "type": "number"
+        },
+        "itemsCount": {
+          "type": "number"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "totalAmount": {
+          "type": "number"
+        },
+        "status": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BasketStatus"
+            }
+          ]
+        },
+        "currency": {
+          "type": "string",
+          "default": ""
+        }
+      },
+      "required": [
+        "id",
+        "voidedItems",
+        "itemsCount",
+        "createdAt",
+        "totalAmount",
+        "status",
+        "currency"
+      ]
+    },
+    "BasketStatus": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "CANCELLED",
+        "SUSPENDED",
+        "FINALIZED",
+        "RESUMED",
+        "PAYMENT",
+        "IMPORTED",
+        "ERROR"
+      ]
+    },
+    "WorkstationChannel": {
+      "type": "string",
+      "enum": [
+        "SCANNGO",
+        "MYSCAN",
+        "ERPOS",
+        "SUPERPOS",
+        "HIICHECKOUT",
+        "MCPE"
+      ]
+    },
+    "WorkstationState": {
+      "type": "string",
+      "enum": [
+        "CLOSED",
+        "IDLE",
+        "ACTIVE",
+        "FINALIZED",
+        "RESCAN",
+        "ERROR",
+        "PAYMENT",
+        "IMPORTED",
+        "ACTION_NEEDED",
+        "CANCELLED"
+      ]
+    },
+    "WorkstationType": {
+      "type": "string",
+      "enum": [
+        "SCO",
+        "POS",
+        "MOBILE_POS",
+        "SCAN_GO"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add 7 ATT external-event JSON schemas under `external-events/att/`:
  - `att.private.notification.baskets.v1.json`
  - `att.private.notification.basket-deleted.v1.json`
  - `att.private.notification.workstations.v1.json`
  - `att.private.notification.workstation-deleted.v1.json`
  - `att.private.notification.tasks.v1.json`
  - `att.private.notification.task-processed.v1.json`
  - `att.private.notification.task-deleted.v1.json`